### PR TITLE
Implement BasicBufferPoolManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +25,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "errno"
@@ -48,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +83,7 @@ name = "limebase"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dashmap",
  "rand",
  "tempfile",
 ]
@@ -67,6 +93,35 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -105,6 +160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +180,18 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.86"
+dashmap = "5.5.3"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,1 @@
+pub mod buffer_pool_manager;

--- a/src/buffer/buffer_pool_manager.rs
+++ b/src/buffer/buffer_pool_manager.rs
@@ -1,0 +1,18 @@
+use crate::{Page, PageGuard, PageId, ReadPageGuard, WritePageGuard};
+
+pub trait BufferPoolManager {
+    fn new(pool_size: usize) -> Self;
+    fn get_pool_size(&self) -> usize;
+    fn get_pages(&self) -> &[Page];
+    fn get_pages_mut(&mut self) -> &mut [Page];
+    fn new_page(&self) -> anyhow::Result<(PageId, Page)>;
+    fn new_page_guarded(&self) -> anyhow::Result<(PageId, PageGuard)>;
+    fn fetch_page(&self, page_id: PageId) -> anyhow::Result<Page>;
+    fn fetch_page_basic(&self, page_id: PageId) -> anyhow::Result<PageGuard>;
+    fn fetch_page_read(&self, page_id: PageId) -> anyhow::Result<ReadPageGuard>;
+    fn fetch_page_write(&self, page_id: PageId) -> anyhow::Result<WritePageGuard>;
+    fn unpin_page(&self, page_id: PageId, is_dirty: bool) -> bool;
+    fn flush_page(&self, page_id: PageId) -> bool;
+    fn flush_all_pages(&self);
+    fn delete_page(&self, page_id: PageId) -> bool;
+}

--- a/src/buffer/buffer_pool_manager.rs
+++ b/src/buffer/buffer_pool_manager.rs
@@ -1,18 +1,293 @@
-use crate::{Page, PageGuard, PageId, ReadPageGuard, WritePageGuard};
+use std::{
+    collections::LinkedList,
+    sync::{
+        atomic::{self, AtomicUsize},
+        Mutex, RwLock,
+    },
+};
+
+use dashmap::DashMap;
+
+use crate::{
+    storage::disk::{DiskManager, LimeBaseDiskManager},
+    Page, PageId,
+};
 
 pub trait BufferPoolManager {
-    fn new(pool_size: usize) -> Self;
     fn get_pool_size(&self) -> usize;
-    fn get_pages(&self) -> &[Page];
-    fn get_pages_mut(&mut self) -> &mut [Page];
-    fn new_page(&self) -> anyhow::Result<(PageId, Page)>;
-    fn new_page_guarded(&self) -> anyhow::Result<(PageId, PageGuard)>;
-    fn fetch_page(&self, page_id: PageId) -> anyhow::Result<Page>;
-    fn fetch_page_basic(&self, page_id: PageId) -> anyhow::Result<PageGuard>;
-    fn fetch_page_read(&self, page_id: PageId) -> anyhow::Result<ReadPageGuard>;
-    fn fetch_page_write(&self, page_id: PageId) -> anyhow::Result<WritePageGuard>;
+    fn get_pages(&self) -> &[RwLock<Page>];
+    fn new_page(&self) -> anyhow::Result<Option<(PageId, &RwLock<Page>)>>;
+    fn fetch_page(&self, page_id: PageId) -> anyhow::Result<Option<&RwLock<Page>>>;
+    /// Unpin the target page from the buffer pool. If page_id is not in the buffer pool or its pin count is already 0, return false.
     fn unpin_page(&self, page_id: PageId, is_dirty: bool) -> bool;
-    fn flush_page(&self, page_id: PageId) -> bool;
-    fn flush_all_pages(&self);
+    fn flush_page(&self, page_id: PageId) -> anyhow::Result<bool>;
+    fn flush_all_pages(&self) -> anyhow::Result<()>;
     fn delete_page(&self, page_id: PageId) -> bool;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct FrameId(usize);
+
+impl FrameId {
+    pub fn new(id: usize) -> Self {
+        Self(id)
+    }
+}
+
+pub struct BufferPoolManagerImpl<'a> {
+    pages: Box<[RwLock<Page>]>,
+    next_page_id: AtomicUsize,
+    page_table: DashMap<PageId, FrameId>,
+    // NOTE: is there lock-free linked list in Rust?
+    /// list of free frames that don't have any pages on them.
+    free_list: Mutex<LinkedList<FrameId>>,
+    disk_manager: &'a LimeBaseDiskManager,
+}
+
+impl<'a> BufferPoolManagerImpl<'a> {
+    pub fn new(pool_size: usize, disk_manager: &'a LimeBaseDiskManager) -> Self {
+        let mut pages = Vec::with_capacity(pool_size);
+        for _ in 0..pool_size {
+            pages.push(Page::new(disk_manager.page_size()));
+        }
+        let pages = pages.into_boxed_slice();
+        let free_list = (0..pool_size).map(FrameId::new).collect();
+        Self {
+            pages,
+            next_page_id: AtomicUsize::new(0),
+            page_table: DashMap::new(),
+            free_list: Mutex::new(free_list),
+            disk_manager,
+        }
+    }
+
+    fn free_frame(&self) -> Option<FrameId> {
+        let mut free_list = self.free_list.lock().unwrap();
+        free_list.pop_front()
+    }
+
+    fn allocate_page(&self) -> PageId {
+        let page_id = self.next_page_id.fetch_add(1, atomic::Ordering::AcqRel);
+        PageId::new(page_id)
+    }
+
+    fn deallocate_page(&self, _page_id: PageId) {
+        // currently noop
+    }
+}
+
+impl<'a> BufferPoolManager for BufferPoolManagerImpl<'a> {
+    fn get_pool_size(&self) -> usize {
+        self.pages.len()
+    }
+
+    fn get_pages(&self) -> &[RwLock<Page>] {
+        &self.pages
+    }
+
+    fn new_page(&self) -> anyhow::Result<Option<(PageId, &RwLock<Page>)>> {
+        let Some(frame_id) = self.free_frame() else {
+            // TODO: evict a unpinned page
+            return Ok(None);
+        };
+
+        let page_id = self.allocate_page();
+        let page = &self.pages[frame_id.0];
+        {
+            let mut page_guard = page.write().unwrap();
+            page_guard.allocate_page(page_id);
+            self.page_table.insert(page_id, frame_id);
+
+            drop(page_guard);
+        }
+
+        Ok(Some((page_id, page)))
+    }
+
+    fn fetch_page(&self, page_id: PageId) -> anyhow::Result<Option<&RwLock<Page>>> {
+        if let Some(frame_id) = self.page_table.get(&page_id) {
+            let page = &self.pages[frame_id.0];
+            return Ok(Some(page));
+        }
+
+        let Some(frame_id) = self.free_frame() else {
+            // TODO: evict a unpinned page
+            return Ok(None);
+        };
+
+        {
+            let mut page_guard = self.pages[frame_id.0].write().unwrap();
+
+            self.disk_manager
+                .read_page(page_id, page_guard.data_mut())?;
+
+            page_guard.allocate_page(page_id);
+
+            drop(page_guard);
+        }
+
+        Ok(Some(&self.pages[frame_id.0]))
+    }
+
+    fn unpin_page(&self, page_id: PageId, is_dirty: bool) -> bool {
+        let Some(frame_id) = self.page_table.get(&page_id) else {
+            // the page is not in the page table
+            return false;
+        };
+        let mut page_guard = self.pages[frame_id.0].write().unwrap();
+        if !page_guard.is_pinned() {
+            return false;
+        }
+        page_guard.unpin();
+        if is_dirty {
+            page_guard.set_dirty();
+        }
+
+        true
+    }
+
+    fn flush_page(&self, page_id: PageId) -> anyhow::Result<bool> {
+        let Some(frame_id) = self.page_table.get(&page_id) else {
+            return Ok(false);
+        };
+        let mut page_guard = self.pages[frame_id.0].write().unwrap();
+        self.disk_manager.write_page(page_id, page_guard.data())?;
+        page_guard.clear_dirty();
+
+        drop(page_guard);
+        Ok(true)
+    }
+
+    fn flush_all_pages(&self) -> anyhow::Result<()> {
+        let guards = self.pages.iter().map(|page| page.write().unwrap());
+        for guard in guards {
+            let Some(page_id) = guard.page_id() else {
+                continue;
+            };
+            self.disk_manager.write_page(page_id, guard.data())?;
+        }
+
+        Ok(())
+    }
+
+    fn delete_page(&self, page_id: PageId) -> bool {
+        let Some(frame_id) = self.page_table.get(&page_id) else {
+            return false;
+        };
+        let mut page_guard = self.pages[frame_id.0].write().unwrap();
+        if page_guard.is_pinned() {
+            return false;
+        }
+
+        let mut free_list = self.free_list.lock().unwrap();
+        free_list.push_back(*frame_id);
+
+        self.deallocate_page(page_id);
+        page_guard.deallocate_page();
+
+        drop(page_guard);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::page::page::DEFAULT_PAGE_SIZE;
+
+    use super::*;
+
+    #[test]
+    fn test_binary_data() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let filename = tempdir.path().join("test.db");
+        const BUFFER_POOL_SIZE: usize = 10;
+        let disk_manager = LimeBaseDiskManager::new(DEFAULT_PAGE_SIZE, filename).unwrap();
+        let buffer_pool_manager = BufferPoolManagerImpl::new(BUFFER_POOL_SIZE, &disk_manager);
+
+        let ret = buffer_pool_manager.new_page().unwrap();
+
+        // The buffer pool is empty. We should be able to create a new page.
+        assert!(
+            ret.is_some(),
+            "The buffer pool is empty. We should be able to create a new page."
+        );
+        let (page_id, page0) = ret.unwrap();
+        assert_eq!(
+            page_id,
+            PageId::new(0),
+            "The buffer pool is empty. We should be able to create a new page."
+        );
+
+        let mut random_binary_data = (0..DEFAULT_PAGE_SIZE)
+            .map(|_| rand::random::<u8>())
+            .collect::<Vec<_>>();
+
+        // Insert terminal characters both in the midddle and at end
+        random_binary_data[BUFFER_POOL_SIZE / 2] = 0;
+        random_binary_data[BUFFER_POOL_SIZE - 1] = 0;
+
+        // Once we have a page, We should be able to read and write content.
+        {
+            let mut page_guard = page0.write().unwrap();
+            page_guard.data_mut().copy_from_slice(&random_binary_data);
+        }
+        {
+            let page_guard = page0.read().unwrap();
+            assert_eq!(
+                page_guard.data(),
+                &random_binary_data,
+                "Once we have a page, We should be able to read and write content."
+            );
+        }
+
+        // We should be able to create new pages until we fill up the buffer pool.
+        for _ in 1..BUFFER_POOL_SIZE {
+            assert!(
+                buffer_pool_manager.new_page().unwrap().is_some(),
+                "We should be able to create new pages until we fill up the buffer pool."
+            );
+        }
+
+        // After unpinning pages {0, 1, 2, 3, 4}, we should be able to create 5 new pages.
+        for page_id in (0..5).map(PageId::new) {
+            assert!(
+                buffer_pool_manager.unpin_page(page_id, true),
+                "{:?} should be able to unpin",
+                page_id
+            );
+
+            buffer_pool_manager.flush_page(page_id).unwrap();
+        }
+        for _ in 0..5 {
+            let ret = buffer_pool_manager.new_page().unwrap();
+            assert!(
+                ret.is_some(),
+                "After unpinning pages {{0, 1, 2, 3, 4}}, we should be able to create 5 new pages."
+            );
+            let (page_id, _page) = ret.unwrap();
+            // Unpin the page here to allow future fetching
+            buffer_pool_manager.unpin_page(page_id, true);
+        }
+
+        let page_id0 = PageId::new(0);
+        // We should be able to fetch the data we wrote a while ago.
+        let page0 = buffer_pool_manager.fetch_page(page_id0).unwrap();
+        assert!(
+            page0.is_some(),
+            "We should be able to fetch the data we wrote a while ago."
+        );
+        let page0 = page0.unwrap();
+        {
+            let page_guard = page0.read().unwrap();
+            assert_eq!(
+                page_guard.data(),
+                &random_binary_data,
+                "We should be able to fetch the data we wrote a while ago."
+            );
+        }
+        assert!(
+            buffer_pool_manager.unpin_page(page_id0, true),
+            "We should be able to unpin page0"
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,7 @@
+pub mod buffer;
 pub mod storage;
+
+pub use storage::page::{
+    page::{Page, PageId},
+    page_guard::{PageGuard, ReadPageGuard, WritePageGuard},
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
 pub mod buffer;
 pub mod storage;
 
-pub use storage::page::{
-    page::{Page, PageId},
-    page_guard::{PageGuard, ReadPageGuard, WritePageGuard},
-};
+pub use storage::page::page::{Page, PageId};

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,1 +1,2 @@
 pub mod disk;
+pub mod page;

--- a/src/storage/page.rs
+++ b/src/storage/page.rs
@@ -1,3 +1,2 @@
 #[allow(clippy::module_inception)]
 pub mod page;
-pub mod page_guard;

--- a/src/storage/page.rs
+++ b/src/storage/page.rs
@@ -1,0 +1,3 @@
+#[allow(clippy::module_inception)]
+pub mod page;
+pub mod page_guard;

--- a/src/storage/page/page.rs
+++ b/src/storage/page/page.rs
@@ -1,0 +1,49 @@
+pub const DEFAULT_PAGE_SIZE: usize = 4096 * 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PageId(usize);
+
+impl PageId {
+    pub fn new(id: usize) -> Self {
+        Self(id)
+    }
+
+    pub fn new_invalid() -> Self {
+        Self(usize::MAX)
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.0 != usize::MAX
+    }
+
+    pub fn offset(&self, page_size: usize) -> usize {
+        self.0 * page_size
+    }
+}
+
+pub struct Page {
+    pub page_id: PageId,
+    pub data: Box<[u8]>,
+}
+
+impl Page {
+    pub fn new(page_size: usize) -> Self {
+        Self {
+            page_id: PageId::new_invalid(),
+            data: vec![0; page_size].into_boxed_slice(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_page_id() {
+        let page_id = PageId::new(42);
+        assert_eq!(page_id.0, 42);
+        let page_size = 4096;
+        assert_eq!(page_id.offset(page_size), 42 * page_size);
+    }
+}

--- a/src/storage/page/page.rs
+++ b/src/storage/page/page.rs
@@ -1,6 +1,8 @@
+use std::{pin::Pin, sync::RwLock};
+
 pub const DEFAULT_PAGE_SIZE: usize = 4096 * 2;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PageId(usize);
 
 impl PageId {
@@ -21,17 +23,85 @@ impl PageId {
     }
 }
 
+#[derive(Debug)]
 pub struct Page {
-    pub page_id: PageId,
-    pub data: Box<[u8]>,
+    page_id: PageId,
+    is_dirty: bool,
+    pin_count: usize,
+    data: Pin<Box<[u8]>>,
 }
 
 impl Page {
-    pub fn new(page_size: usize) -> Self {
+    pub fn new_raw(page_size: usize) -> Self {
+        let buf = vec![0; page_size].into_boxed_slice();
         Self {
             page_id: PageId::new_invalid(),
-            data: vec![0; page_size].into_boxed_slice(),
+            is_dirty: false,
+            pin_count: 0,
+            data: Pin::new(buf),
         }
+    }
+
+    pub fn new(page_size: usize) -> RwLock<Self> {
+        RwLock::new(Self::new_raw(page_size))
+    }
+
+    pub fn allocate_page(&mut self, page_id: PageId) {
+        self.page_id = page_id;
+        self.pin_count += 1;
+    }
+
+    pub fn is_pinned(&self) -> bool {
+        self.pin_count > 0
+    }
+
+    pub fn set_dirty(&mut self) {
+        self.is_dirty = true;
+    }
+
+    pub fn clear_dirty(&mut self) {
+        self.is_dirty = false;
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.is_dirty
+    }
+
+    pub fn pin(&mut self) {
+        self.pin_count += 1;
+    }
+
+    pub fn unpin(&mut self) {
+        self.pin_count = self.pin_count.saturating_sub(1);
+    }
+
+    pub fn deallocate_page(&mut self) {
+        self.page_id = PageId::new_invalid();
+        self.is_dirty = false;
+    }
+
+    pub fn page_id(&self) -> Option<PageId> {
+        if self.page_id == PageId::new_invalid() {
+            None
+        } else {
+            Some(self.page_id)
+        }
+    }
+
+    pub fn is_allocated(&self) -> bool {
+        self.page_id != PageId::new_invalid()
+    }
+
+    pub fn page_size(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        &mut self.data
     }
 }
 

--- a/src/storage/page/page_guard.rs
+++ b/src/storage/page/page_guard.rs
@@ -1,6 +1,0 @@
-// unimplemented
-pub struct PageGuard;
-// unimplemented
-pub struct ReadPageGuard;
-// unimplemented
-pub struct WritePageGuard;

--- a/src/storage/page/page_guard.rs
+++ b/src/storage/page/page_guard.rs
@@ -1,0 +1,6 @@
+// unimplemented
+pub struct PageGuard;
+// unimplemented
+pub struct ReadPageGuard;
+// unimplemented
+pub struct WritePageGuard;


### PR DESCRIPTION
 - implement basic buffer pool manager
 - there are NOT any optimizations implemented
 - this buffer pool manager does not have buffer replacement policy implementation
   - currently if we have to find a frame for new/fetching page, just iterate over pages, and find pages not in use or evictable (unpinned) 